### PR TITLE
Fix cloudflareClass.php

### DIFF
--- a/libraries/cloudflareClass.php
+++ b/libraries/cloudflareClass.php
@@ -259,6 +259,8 @@ class cloudflare {
 		$script  = str_replace(array(")+", ").$siteLen"), array(").", ")+$siteLen"), $script);	
 		// take out any source of javascript comment code - #JS Comment Fix
 		$script  = preg_replace("/'[^']+'/", "", $script);
+		// Fix
+		$script  = str_replace('f.action+=location.hash;', '', $script);
 		// evaluate PHP script
 		eval($script);
 		// if cloudflare answer has been found, store it 


### PR DESCRIPTION
Fix error:
"PHP Parse error:  syntax error, unexpected '+=' (T_PLUS_EQUAL) in libraries/cloudflareClass.php(263) : eval()'d code on line 7"