### PR TITLE
Cloudflare bypass 24 post request

### DIFF
--- a/v2/examples/curl.php
+++ b/v2/examples/curl.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use CloudflareBypass\RequestMethod\CFCurl;
 
 $curl_cf_wrapper = new CFCurl(array(
-    'cache'         => true,   // Caches clearance tokens into Cache/ folder under md5(site host)
+    'cache'         => true,   // Caching now enabled by default; stores clearance tokens in Cache folder
     'max_attempts'  => 5       // Max attempts to try and get CF clearance
 ));
 

--- a/v2/examples/streamcontext.php
+++ b/v2/examples/streamcontext.php
@@ -4,7 +4,7 @@ require __DIR__ . '/../vendor/autoload.php';
 use CloudflareBypass\RequestMethod\CFStreamContext;
 
 $stream_cf_wrapper = new CFStreamContext(array(
-    'cache'         => true,  // Caches clearance tokens into Cache/ folder under md5(site host)
+    'cache'         => true,  // Caching now enabled by default; stores clearance tokens in Cache folder
     'max_attempts'  => 5      // Max attempts to try and get CF clearance
 ));
 

--- a/v2/src/CloudflareBypass/CFCore.php
+++ b/v2/src/CloudflareBypass/CFCore.php
@@ -13,7 +13,7 @@ class CFCore extends CFBypass
      * Use caching mechanism.
      * @var bool
      */
-    protected $cache;
+    protected $cache = true;
 
     /**
      * Configuration properties:

--- a/v2/src/CloudflareBypass/CFCore.php
+++ b/v2/src/CloudflareBypass/CFCore.php
@@ -31,13 +31,6 @@ class CFCore extends CFBypass
     {
         // Set $this->cache
         if (isset($config['cache']) && $config['cache']) {
-            // Create Cache/ directory if it does not exist.
-            $dir = __DIR__ . '/Cache';
-            
-            if (!is_dir($dir)) {
-                mkdir($dir, 0777);
-            }
-
             $this->cache = new Storage();
         }
 

--- a/v2/src/CloudflareBypass/RequestMethod/CFStreamContext.php
+++ b/v2/src/CloudflareBypass/RequestMethod/CFStreamContext.php
@@ -17,20 +17,11 @@ class CFStreamContext extends \CloudflareBypass\CFCore
      */
     public function create($url, $context, $stream = null, $root_scope = true, $attempt = 1)
     {
-        $method = null;
-        $follow_location = 0;
-
         if ($root_scope) {
             // Extract array if context is a resource.
             if (is_resource($context)) {
                 $context = stream_context_get_options($context);
             }
-
-            // Store original request method.
-            $method = isset($context['http']['method']) ? $context['http']['method'] : 'GET';
-
-            // Store original follow location.
-            $follow_location = isset($context['http']['follow_location']) ? $context['http']['follow_location'] : 1;        
 
             $stream = new StreamContext($url, $context);
 
@@ -39,71 +30,70 @@ class CFStreamContext extends \CloudflareBypass\CFCore
                 $components = parse_url($url);
 
                 if (($cached = $this->cache->fetch($components['host'])) !== false) {
-                    // Use cached clearance tokens.
-                    $stream->setCookie('__cfduid', str_replace('__cfduid=', '', $cached['__cfduid']));
-                    $stream->setCookie('cf_clearance', str_replace('cf_clearance=', '', $cached['cf_clearance']));
+                    // Set clearance tokens.
+                    $stream->setCookie('__cfduid', $cached['__cfduid']);
+                    $stream->setCookie('cf_clearance', $cached['cf_clearance']);
                 }
             }
-
-            // Set to GET request.
-            $stream->setHttpContextOption('method', 'GET');
         }
 
-        // Request page.
+        // Request original page.
         $response = $stream->fileGetContents();
         $response_info = array(
             'http_code'     => $stream->getResponseHeader('http_code')
         );
 
-        // Check if page is protected by Cloudflare.
-        if (!$this->isProtected($response, $response_info)) {
-            // Set original request method.
-            $stream->setHttpContextOption('method', $method);
+        if ($root_scope) {
+            // Check if page is protected by Cloudflare.
+            if (!$this->isProtected($response, $response_info)) {
+                return $stream->getContext();
+            }
 
-            return stream_context_create($stream->getContext());
+            /*
+             * 1. Check if user agent is set in context
+             */
+            if (!$stream->getRequestHeader('User-Agent')) {
+                throw new \ErrorException('User agent needs to be set in context!');
+            }
+
+            /*
+             * 2. Extract "__cfuid" cookie
+             */
+            if (!($cfduid_cookie = $stream->getCookie('__cfduid'))) {
+                return $stream->getContext();
+            }
+
+            // Clone streamcontext object handle.
+            $stream_copy = $stream->copyHandle();
+            $stream_copy->setCookie('__cfduid', $cfduid_cookie);
+        } else {
+            // Not in root scope so $stream is a clone.
+            $stream_copy = $stream;
         }
-
-        /*
-         * 1. Check if user agent is set in context
-         */
-        if ($root_scope && !$stream->getRequestHeader('User-Agent')) {
-            throw new \ErrorException('User agent needs to be set in context!');
-        }
-
-        /*
-         * 2. Extract "__cfuid" cookie
-         */
-        if (!($cfduid_cookie = $stream->getCookie('__cfduid'))) {
-            // Set original request method.
-            $stream->setHttpContextOption('method', $method);
-
-            return stream_context_create($stream->getContext());
-        }
-
-        $stream->setCookie('__cfduid', str_replace('__cfduid=', '', $cfduid_cookie));
 
         /*
          * 3. Solve challenge and request clearance link
          */
-        $stream->setURL($this->getClearanceLink($response, $url));
-        $stream->setHttpContextOption('follow_location', 0);
+        $stream_copy->setURL($this->getClearanceLink($response, $url));
+        $stream_copy->setHttpContextOption('follow_location', 1);
 
-        // Request clearance page.
-        $stream->fileGetContents();
+        // GET clearance link.
+        $stream_copy->setHttpContextOption('method', 'GET');
+        $stream_copy->fileGetContents();
 
         /*
          * 4. Extract "cf_clearance" cookie
          */
-        if (!($cfclearance_cookie = $stream->getCookie('cf_clearance'))) {
+        if (!($cfclearance_cookie = $stream_copy->getCookie('cf_clearance'))) {
             if ($retry > $this->max_retries) {
                 throw new \ErrorException("Exceeded maximum retries trying to get CF clearance!");   
             }
             
-            list($cfduid_cookie, $cfclearance_cookie) = $this->create($url, false, $stream, false, $retry+1);
+            $cfclearance_cookie = $this->create($url, false, $stream_copy, false, $retry+1);
         }
 
-        if ($cfclearance_cookie && !$root_scope) {
-            return array($cfduid_cookie, $cfclearance_cookie);
+        if (!$root_scope) {
+            return $cfclearance_cookie;
         }
 
         if (isset($this->cache)) {
@@ -117,22 +107,12 @@ class CFStreamContext extends \CloudflareBypass\CFCore
         }
 
         /*
-         * 5. Revert all stream options.
+         * 5. Set "__cfduid" and "cf_clearance" in original stream
          */
+        $stream->setCookie('__cfduid', $cfduid_cookie);
+        $stream->setCookie('cf_clearance', $cfclearance_cookie);
+        $stream->updateContext();
 
-        // Set original URL.
-        $stream->setURL($url);
-
-        // Set original follow location.
-        $stream->setHttpContextOption('follow_location', $follow_location);
-
-        // Set original request method.
-        $stream->setHttpContextOption('method', $method);
-
-        // Set clearance tokens.
-        $stream->setCookie('__cfduid', str_replace('__cfduid=', '', $cfduid_cookie));
-        $stream->setCookie('cf_clearance', str_replace('cf_clearance=', '', $cfclearance_cookie));
-
-        return stream_context_create($stream->getContext());
+        return $stream->getContext();
     }
 }

--- a/v2/src/CloudflareBypass/RequestMethod/CFStreamContext.php
+++ b/v2/src/CloudflareBypass/RequestMethod/CFStreamContext.php
@@ -31,8 +31,9 @@ class CFStreamContext extends \CloudflareBypass\CFCore
 
                 if (($cached = $this->cache->fetch($components['host'])) !== false) {
                     // Set clearance tokens.
-                    $stream->setCookie('__cfduid', $cached['__cfduid']);
-                    $stream->setCookie('cf_clearance', $cached['cf_clearance']);
+                    foreach ($cached as $cookie => $val) {
+                        $stream->setCookie($cookie, $val);
+                    }
                 }
             }
         }
@@ -97,13 +98,15 @@ class CFStreamContext extends \CloudflareBypass\CFCore
         }
 
         if (isset($this->cache)) {
+            $cookies = array();
             $components = parse_url($url);
 
-            // Store cookies in cache            
-            $this->cache->store($components['host'], array(
-                '__cfduid'      => $cfduid_cookie,
-                'cf_clearance'  => $cfclearance_cookie
-            ));
+            foreach ($stream_copy->getCookies() as $cookie => $val) {
+                $cookies[$cookie] = $val;
+            }
+
+            // Store clearance tokens in cache.
+            $this->cache->store($components['host'], $cookies);
         }
 
         /*

--- a/v2/src/CloudflareBypass/RequestMethod/Curl.php
+++ b/v2/src/CloudflareBypass/RequestMethod/Curl.php
@@ -38,6 +38,26 @@ class Curl
     }
 
     /**
+     * Get request headers set for current request.
+     *
+     * @access public
+     */
+    public function getRequestHeaders()
+    {
+        return $this->request_headers;
+    }
+
+    /**
+     * Get cookies set for current request.
+     *
+     * @access public
+     */
+    public function getCookies()
+    {
+        return $this->cookies;
+    }
+
+    /**
      * Enables cURL object handle to fetch and store response headers and cookies.
      * WARNING: Overrides "CURLOPT_HEADERFUNCTION".
      *
@@ -178,13 +198,13 @@ class Curl
 
         if (strpos($header, 'Cookie') !== false) {
             // Convert string into array of cookies.
-            $cookies = explode(';', $header);
+            $cookies = explode(';', substr($header, strpos($header, ':')+1));
             $cookies_count = count($cookies);
 
             // Store cookies.
             for ($i=0; $i<$cookies_count; $i++) {
-                list($cookie, $val) = explode('=', $cookies[$i]);
-                $this->cookies[$cookie] = $val . ';';                   
+                list($cookie, $val) = explode('=', trim($cookies[$i]));
+                $this->cookies[$cookie] = $cookie . '=' . $val . ';';                   
             }
         }
     }
@@ -201,7 +221,7 @@ class Curl
     {
         if (strpos($header, 'Set-Cookie') !== false) {
             // Match cookie name and value.
-            preg_match('/Set-Cookie: (\w+)(.+)/', $header, $matches);
+            preg_match('/Set\-Cookie: ([^=]+)(.+)/', $header, $matches);
             $this->cookies[$matches[1]] = $matches[1] . $matches[2];
         }
 

--- a/v2/src/CloudflareBypass/Storage.php
+++ b/v2/src/CloudflareBypass/Storage.php
@@ -4,6 +4,24 @@ namespace CloudflareBypass;
 class Storage
 {
     /**
+     * Creates Cache/ directory if it does NOT exist
+     *
+     * @access public
+     * @throws \ErrorException if cache directory CAN NOT be created
+     */
+    public function __construct()
+    {
+        // Create Cache/ directory if it does not exist.
+        $dir = __DIR__ . '/Cache';
+        
+        if (!is_dir($dir)) {
+            if (!mkdir($dir, 0777)) {
+                throw new \ErrorException('Unable to create Cache directory!');
+            }
+        }
+    }
+
+    /**
      * Returns clearance tokens from the specified cache file.
      *
      * @access public

--- a/v2/src/CloudflareBypass/Storage.php
+++ b/v2/src/CloudflareBypass/Storage.php
@@ -74,7 +74,6 @@ class Storage
 
         if (!(
             is_array($clearance_tokens) && 
-            count($clearance_tokens) === 2 &&
             isset($clearance_tokens['__cfduid']) &&
             isset($clearance_tokens['cf_clearance'])
         )) {


### PR DESCRIPTION
- Fixed cookie storage bug in CFCurl and CFStreamContext
- Cleaned up CFStreamContext to make it follow a similar process to CFCurl
- Cookies set throughout the bypassing process are now stored in Cache with clearance tokens. (Session vars should now be retained).
-  Custom follow location implemented for CFStreamContext, as "follow_location" only shows headers from first redirect.
- Some other fixes.