### PR TITLE
Feature v2 request variant fixes and docs

### DIFF
--- a/src/CloudflareBypass/Base/RequestMethod/RequestMethod.php
+++ b/src/CloudflareBypass/Base/RequestMethod/RequestMethod.php
@@ -1,39 +1,194 @@
 <?php
 namespace CloudflareBypass\Base\RequestMethod;
 
+/**
+ * All request methods should implement this interface.
+ * This interface states all methods required by CFBypasser.
+ *
+ * @author Kyran Rana
+ */
 interface RequestMethod {
 
     // {{{ Getters
 
-    public function getPage();                                  // Gets page results.
-    public function getPageInfo();                              // Gets page headers (http_code, url).
-    
-    public function getResource();                              // Gets resource.
-    public function getCopyOfResource();                        // Gets copy of resource.
+    /**
+     * Gets page for current request.
+     * -> Should update cookies
+     * -> Should update http code 
+     * -> Should clear and update request headers.
+     * -> Should clear and update response headers.
+     *
+     * @access public
+     * @return string  page contents.
+     */
+    public function getPage();
 
-    public function getCookies();                               // Gets cookies for current request.
-    public function getCookie( $cookie );                       // Gets cookie for current request.
-    
-    public function getRequestHeader( $request_header );        // Gets request header.
+
+    /**
+     * Gets http code for current request.
+     *
+     * @access public
+     * @return integer  http code.
+     */
+    public function getHttpCode();
+
+
+    /**
+     * Gets url for current request.
+     *
+     * @access public
+     * @return string  url.
+     */
+    public function getUrl();
+
+
+    /**
+     * Gets all cookies for current request.
+     *
+     * @access public
+     * @return object  all cookies.
+     *
+     * Format
+     *
+     * cURL:
+     * {
+     *  "cookie1": "Hostname=<string>;? Subdomain=<true|false>; Path=path;? Secure=<true|false>;? Expires=<date>;? Name=<string>; Value=<string>;",
+     *  "cookie2": "Hostname=<string>;? Subdomain=<true|false>; Path=path;? Secure=<true|false>;? Expires=<date>;? Name=<string>; Value=<string>;"
+     * }
+     *
+     * Stream context:
+     * {
+     *  "cookie1": "Name=<string>; Value=<string>;",
+     *  "cookie2": "Name=<string>; Value=<string>;"
+     * }
+     *
+     */
+    public function getCookies();
+
+
+    /**
+     * Gets cookie named :cookie for current request.
+     *
+     * @access public
+     * @param string $cookie  cookie name
+     * @return mixed  cookie value | null
+     *
+     * Format
+     *
+     * cURL:
+     * "Hostname=<string>;? Subdomain=<true|false>; Path=<string>;? Secure=<true|false>;? Expires=<date>;? Name=<string>; Value=<string>;"
+     *
+     * Stream context:
+     * "Name=<string>; Value=<string>;"
+     */
+    public function getCookie( $cookie );
+
+
+    /**
+     * Gets request handle.
+     *
+     * @access public
+     * @return object  request handle.
+     */
+    public function getResource();
+
+
+    /**
+     * Gets CF request handle.
+     * - Handle with all required options set to bypass CF.
+     *
+     * @access public
+     * @return object  cf request handle
+     */
+    public function getCFResource();
+
+
+    /**
+     * Gets request headers for current request.
+     *
+     * @access public
+     * @return array  request headers.
+     *
+     * Format:
+     * [
+     *   "user-agent: <user agent>",
+     *   "cookie: <cookie>",
+     *   "no-cache: <cache header>"
+     * ]
+     */
+    public function getRequestHeaders();
+
+
+    /**
+     * Gets request header :header for current request.
+     *
+     * @access public
+     * @param string $header  header name
+     * @return mixed  header value | null
+     */
+    public function getRequestHeader( $request_header );
+
+
+    /**
+     * Gets response headers for current request.
+     *
+     * @access public
+     * @return array  response headers.
+     * 
+     * Format:
+     * [
+     *   "HTTP/1.1 200 OK",
+     *   "Accept-Ranges: bytes",
+     *   "Set-Cookie: <set cookie>"
+     * ]
+     */
+    public function getResponseHeaders();
 
     // }}}
 
-
+    // ------------------------------------------------------------------------------------------------
 
     // {{{ Setters
 
-    public function setUrl( $url );                             // Sets url.
-    public function setCookie( $cookie );                       // Sets cookie.
-    public function setVerboseMode( $verbose_mode );            // Sets verbose mode. 
-    public function setFollowLocation( $follow_location );      // Sets follow location.
+    /**
+     * Sets url for current request.
+     *
+     * @access public
+     * @param string $url  current url.
+     * @return void
+     */
+    public function setUrl( $url );
+    
 
-    // }}}
- 
+    /**
+     * Sets cookie for current request.
+     *
+     * @access public
+     * @param string $name  cookie name.
+     * @param string $value  cookie value.
+     * @return void
+     */
+    public function setCookie( $name, $value );
 
 
-    // {{{ Showers
+    /**
+     * Sets follow location for current request.
+     *
+     * @access public
+     * @param boolean $follow  TRUE to enable follow location.
+     * @return void
+     */
+    public function setFollowLocation( $follow );
 
-    public function showRequestHeaders();                       // Enables request headers to be shown
+
+    /**
+     * Sets request method for current request.
+     * 
+     * @access public
+     * @param string $request_method  request method.
+     * @return void
+     */
+    public function setRequestMethod( $request_method );
 
     // }}}
 }

--- a/src/CloudflareBypass/RequestMethod/Curl.php
+++ b/src/CloudflareBypass/RequestMethod/Curl.php
@@ -8,13 +8,22 @@ namespace CloudflareBypass\RequestMethod;
 class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
 {
     /**
-     * Request headers per request.
+     * Request headers.
+     *
      * @var array
      */
     private $request_headers = array();
 
     /**
+     * Response headers.
+     *
+     * @var array
+     */
+    private $response_headers = array();
+
+    /**
      * cURL handle.
+     *
      * @var resource
      */
     private $ch;
@@ -28,15 +37,19 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
      * @param resource $curl cURL handle
      * @throws \ErrorException if $ch IS NOT a cURL handle
      */
-    public function __construct($ch = null)
+    public function __construct( $ch=null )
     {
-        if (!is_resource($ch))
+        if (!is_resource( $ch ))
             throw new \ErrorException('Curl handle is required!');
 
         $this->ch = $ch;
+
+        // secretly enable cookie engine.
+        $this->setOpt( CURLOPT_COOKIELIST, "" );
     }
 
 
+    // ------------------------------------------------------------------------------------------------
 
     // {{{ cURL Functions 
 
@@ -49,52 +62,44 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
      * @param mixed $val
      * @return bool
      */
-    public function setopt( $opt, $val )
+    public function setOpt( $opt, $val )
     {
         return curl_setopt( $this->ch, $opt, $val );
     }
 
 
     /**
-     * Gets page.
+     * Gets cURL info object.
      *
      * @access public
-     * @see http://php.net/curl_exec
-     * @return string  Page contents
+     * @see http://php.net/curl_getinfo
+     * @param resource $ch
+     * @param mixed $opt
+     * @return object
      */
-    public function getPage()
+    public function getInfo( $opt=null )
     {
-        $this->request_headers = array();
+        $args = array();
+        $args[] = $this->ch;
 
-        $response           = curl_exec( $this->ch );
-        $response_info      = curl_getinfo( $this->ch );
-
-        if (isset( $response_info['request_header'] )) {
-            // Converts string full of headers into an array of headers.
-            $headers = preg_split( "/\r\n|\n/", $response_info['request_header'] );
-
-            $this->setRequestHeaders( $headers );
+        if (func_num_args()) {
+            $args[] = $opt;
         }
 
-        return $response;
+        return call_user_func_array( 'curl_getinfo', $args );
     }
 
 
     /**
-     * Get page info
-     *
+     * Executes cURL request.
+     * 
      * @access public
-     * @param mixed $opt
-     * @return array
+     * @see http://php.net/curl_exec
+     * @return string
      */
-    public function getPageInfo( $opt = null )
+    public function exec()
     {
-        $args = [ $this->ch ];
-
-        if (func_num_args())
-            $args[] = $opt;
-        
-        return call_user_func_array( 'curl_getinfo', $args );
+        return curl_exec( $this->ch );
     }
 
 
@@ -111,9 +116,108 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
 
     // }}}
 
-
+    // ------------------------------------------------------------------------------------------------
 
     // {{{ Getters
+
+    // {{{ RequestMethod getters
+
+    /**
+     * Executes current request.
+     *
+     * @access public
+     * @return string  page contents
+     */
+    public function getPage()
+    {
+        // clear request headers
+        $this->request_headers = array();
+
+        // clear response headers
+        $this->response_headers = array();
+
+        $response   = $this->exec();
+        $info       = $this->getInfo();
+
+        if (isset( $info['request_header'] )) {
+            // set request headers
+            $this->request_headers = preg_split( "/\r\n|\n/", $info['request_header'] );
+        }
+
+        return $response;
+    }
+
+
+    /**
+     * Gets http code for current request.
+     *
+     * @access public
+     * @return integer  http code
+     */
+    public function getHttpCode()
+    {
+        return $this->getInfo( CURLINFO_HTTP_CODE );
+    }
+
+
+    /**
+     * Gets url for current request.
+     *
+     * @access public
+     * @return string  url.
+     */
+    public function getUrl()
+    {
+        $info = $this->getInfo();
+
+        return $info['url'];
+    }
+
+
+    /**
+     * Gets all cookies for current request.
+     * 
+     * @access public
+     * @return array  all cookies.
+     */
+    public function getCookies()
+    {
+        $cookies        = $this->getInfo( CURLINFO_COOKIELIST );
+        $new_cookies    = array();
+
+        foreach ($cookies as $cookie) {
+            // Reference: https://curl.haxx.se/libcurl/c/CURLOPT_COOKIELIST.html
+            list( $hostname, $subdomain, $path, $secure, $expiry, $name, $value ) = explode( "\t", $cookie );
+
+            $new_cookies[strtolower( $name )] = sprintf( 
+                "Hostname=%s; Subdomain=%s; Path=%s; Secure=%s; Expiry=%s; Name=%s; Value=%s;",
+
+                $hostname, $subdomain, $path, $secure, $expiry, $name, $value );
+        }
+
+        return $new_cookies;
+    }
+
+
+    /**
+     * Get cookie set for current request.
+     * 
+     * @access public
+     * @param string $cookie  cookie name.
+     * @return mixed  cookie value | null
+     */
+    public function getCookie( $cookie )
+    {
+        $cookies    = $this->getCookies();
+        $cookie     = strtolower( $cookie );
+
+        if (isset( $cookies[$cookie] )) {
+            return $cookies[$cookie];
+        }
+
+        return null;
+    }
+
 
     /**
      * Get cURL handle
@@ -128,49 +232,34 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
 
 
     /**
-     * Gets copy of cURL handle
+     * Gets CF handle.
      *
      * @access public
-     * @return resource  Copy of cURL handle.
+     * @return resource  CF handle.
      */
-    public function getCopyOfResource()
+    public function getCFResource()
     {
-        $ch = curl_copy_handle( $this->ch );
+        $ch = new Curl( curl_copy_handle( $this->ch ) );
 
-        return new Curl( $ch );
+        $ch->setOpt( CURLINFO_HEADER_OUT,       true );    
+        $ch->setOpt( CURLOPT_HEADERFUNCTION,    array( $ch, 'setResponseHeader' ) );
+
+        // secretly enable cookie engine.
+        $ch->setOpt( CURLOPT_COOKIELIST, "" );
+
+        return $ch;
     }
 
 
     /**
-     * Gets all cookies.
-     * 
+     * Get request headers for current request.
+     *
      * @access public
-     * @return array  All cookies.
+     * @return array  request headers
      */
-    public function getCookies()
+    public function getRequestHeaders()
     {
-        return $this->getPageInfo( CURLINFO_COOKIELIST );
-    }
-
-
-    /**
-     * Get cookie set for current request.
-     * 
-     * @access public
-     * @param string $cookie  Cookie name.
-     * @return mixed  Cookie value | null
-     */
-    public function getCookie( $cookie )
-    {
-        foreach( $this->getCookies() as $cookieString ) {
-            // Reference: https://curl.haxx.se/libcurl/c/CURLOPT_COOKIELIST.html
-            list( $hostname, $subdomains, $path, $secure, $expiry, $name, $value ) = explode( "\t", $cookieString );
-
-            if (strtolower( $name ) === strtolower( $cookie ))
-                return $value;
-        }
-
-        return null;
+        return $this->request_headers;
     }
 
 
@@ -183,29 +272,51 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
      */
     public function getRequestHeader( $header )
     {
-        $header = strtolower( $header );
+        foreach ($this->request_headers as $rheader) {
+            if (strpos( $rheader, ':' ) !== false) {
+                list( $name, $value ) = explode( ':', $rheader );
 
-        if (isset( $this->request_headers[$header] ))
-            return $this->request_headers[$header];
+                if (strtolower( $name ) === strtolower( $header )) {
+                    return $value;
+                }
+            }
+        }
 
         return null;
     }
 
+
+    /**
+     * Get response headers for current request.
+     *
+     * @access public
+     * @return array  response headers.
+     */
+    public function getResponseHeaders()
+    {
+        return $this->response_headers;
+    }
+
     // }}}
 
+    // }}}
 
+    // ------------------------------------------------------------------------------------------------
 
     // {{{ Setters
+
+    // {{{ RequestMethod setters
 
     /**
      * Sets url for current request.
      *
      * @access public
-     * @param string $url  New url.
+     * @param string $url  new url.
+     * @return void
      */
     public function setUrl( $url )
     {
-        $this->setopt( CURLOPT_URL, $url );
+        $this->setOpt( CURLOPT_URL, $url );
     }
 
 
@@ -213,11 +324,12 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
      * Sets follow location for current request.
      *
      * @access public
-     * @param boolean $follow_location  Follow location.
+     * @param boolean $follow  TRUE to follow location.
+     * @return void
      */
-    public function setFollowLocation( $follow_location )
+    public function setFollowLocation( $follow )
     {
-        $this->setopt( CURLOPT_FOLLOWLOCATION, $follow_location );
+        $this->setOpt( CURLOPT_FOLLOWLOCATION, $follow );
     }
 
 
@@ -225,23 +337,20 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
      * Set cookie for current request.
      *
      * @access public
-     * @param string $cookie  Cookie to set.
+     * @param string $name  cookie to set.
+     * @param string $value  value for cookie.
+     * @return void
      */
-    public function setCookie( $cookie )
+    public function setCookie( $name, $value )
     {
-        $this->setopt( CURLOPT_COOKIELIST, $cookie );
-    }
+        $cookie = implode( "\t", array_map( function( $elem ) {
+            
+            list( $_, $val ) = explode( '=', $elem );
+            return substr( $val, 0, -1 );
 
+        }, explode( " ", $value )) );
 
-    /**
-     * Sets verbose mode.
-     * 
-     * @access public
-     * @param boolean $verbose_mode  Verbose mode.
-     */
-    public function setVerboseMode( $verbose_mode )
-    {
-        $this->setopt( CURLOPT_VERBOSE, $verbose_mode );
+        $this->setOpt( CURLOPT_COOKIELIST, $cookie );
     }
 
 
@@ -253,49 +362,36 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
      */
     public function setRequestMethod( $request_method )
     {
-        if ($request_method === "GET")
-            $this->setopt( CURLOPT_HTTPGET, true );
-    
-        $this->setopt( CURLOPT_CUSTOMREQUEST, $request_method );
+        if ($request_method === "GET") {
+            $this->setOpt( CURLOPT_HTTPGET, true );
+        }
+
+        $this->setOpt( CURLOPT_CUSTOMREQUEST, $request_method );
     }
 
     // }}}
 
+    // }}}
 
+    // ------------------------------------------------------------------------------------------------
 
     // {{{ Private Setters
 
     /**
-     * Sets request headers for current request.
+     * Adds response header to response header array for current request.
      *
      * @access private 
-     * @param string $headers  Request headers.
+     * @param resource $ch  cURL handle.
+     * @param string $header  response header.
+     * @return integer  response header length.
      */
-    private function setRequestHeaders( $headers )
+    public function setResponseHeader( $ch, $header )
     {
-        foreach ($headers as $header) {
-            if (strpos( $header, ':' ) !== false) {
-                list( $name, $value ) = explode( ':', $header );
-                
-                $this->request_headers[strtolower( $name )] = strtolower( $value );
-            }
+        if (trim( $header ) !== "") {
+            $this->response_headers[] = trim( $header );
         }
-    }
 
-    // }}}
-
-
-
-    // {{{ Showers 
-
-    /**
-     * Enables request headers to be shown in info object.
-     * 
-     * @access public
-     */
-    public function showRequestHeaders()
-    {
-        $this->setopt( CURLINFO_HEADER_OUT, true );
+        return mb_strlen( $header );
     }
 
     // }}}

--- a/tests/src/CloudflareBypass/CFBypassTest.php
+++ b/tests/src/CloudflareBypass/CFBypassTest.php
@@ -5,6 +5,7 @@ use CloudflareBypass\CFBypass;
 
 /**
  * CF Bypass utility tests
+ * -> testAssemble          - Checks if "assemble" correctly assembles the clearance link.
  * -> testGetJschlVc        - Checks if "getJschlVC" extracts correct jschl vc value from iuam doc.
  * -> testGetJschlPass      - Checks if "getJschlPass" extracts correct pass value from iuam doc.
  * -> testGetJschlAnswer    - Checks if "getJschlAnswer" extracts correct jschl answer value from iuam doc. 
@@ -14,85 +15,599 @@ class CFBypassTest extends TestCase
     protected static $bypass_files = [];
 
     /**
-     * Setup before test case class
+     * Called before test case class.
+     *
      * @return void.
      */
     public static function setUpBeforeClass() {
-        $test_files_dir = implode( DIRECTORY_SEPARATOR, [ __DIR__, '..', '..', 'files' ] );
+        self::$bypass_files = [
+            'cfbypass1.html' => [
+                'file' => <<<CFBYPASS1
 
-        if ($dir_handle = opendir( $test_files_dir )) {
-            while (false !== ($filename = readdir( $dir_handle ))) {
-                // do not use use special directories.
-                if ($filename === '.' || $filename === '..')
-                    continue;
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Just a moment...</title>
+  <style type="text/css">
+    html, body {width: 100%; height: 100%; margin: 0; padding: 0;}
+    body {background-color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 100%;}
+    h1 {font-size: 1.5em; color: #404040; text-align: center;}
+    p {font-size: 1em; color: #404040; text-align: center; margin: 10px 0 0 0;}
+    #spinner {margin: 0 auto 30px auto; display: block;}
+    .attribution {margin-top: 20px;}
+    @-webkit-keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    @keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    .bubbles { background-color: #404040; width:15px; height: 15px; margin:2px; border-radius:100%; -webkit-animation:bubbles 0.6s 0.07s infinite ease-in-out; animation:bubbles 0.6s 0.07s infinite ease-in-out; -webkit-animation-fill-mode:both; animation-fill-mode:both; display:inline-block; }
+  </style>
 
-                self::$bypass_files[] = [
-                    'name'          => $filename,
-                    'content'       => file_get_contents( $test_files_dir . DIRECTORY_SEPARATOR . $filename )
-                ];
-            }
-        
-            closedir( $dir_handle );
-        }
+    <script type="text/javascript">
+  //<![CDATA[
+  (function(){
+    var a = function() {try{return !!window.addEventListener} catch(e) {return !1} },
+    b = function(b, c) {a() ? document.addEventListener("DOMContentLoaded", b, c) : document.attachEvent("onreadystatechange", b)};
+    b(function(){
+      var a = document.getElementById('cf-content');a.style.display = 'block';
+      setTimeout(function(){
+        var s,t,o,p,b,r,e,a,k,i,n,g,f, IHGYwhs={"JNZFCezHZZ":+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))};
+        t = document.createElement('div');
+        t.innerHTML="<a href='/'>x</a>";
+        t = t.firstChild.href;r = t.match(/https?:\/\//)[0];
+        t = t.substr(r.length); t = t.substr(0,t.length-1);
+        a = document.getElementById('jschl-answer');
+        f = document.getElementById('challenge-form');
+        ;IHGYwhs.JNZFCezHZZ+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]));IHGYwhs.JNZFCezHZZ-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+[])+(+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]));IHGYwhs.JNZFCezHZZ-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]));IHGYwhs.JNZFCezHZZ+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]));IHGYwhs.JNZFCezHZZ-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]));a.value = +IHGYwhs.JNZFCezHZZ.toFixed(10) + t.length; '; 121'
+        f.action += location.hash;
+        f.submit();
+      }, 4000);
+    }, false);
+  })();
+  //]]>
+</script>
+
+
+</head>
+<body>
+  <table width="100%" height="100%" cellpadding="20">
+    <tr>
+      <td align="center" valign="middle">
+          <div class="cf-browser-verification cf-im-under-attack">
+  <noscript><h1 data-translate="turn_on_js" style="color:#bd2426;">Please turn JavaScript on and reload the page.</h1></noscript>
+  <div id="cf-content" style="display:none">
+    
+    <div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+    </div>
+    <h1><span data-translate="checking_browser">Checking your browser before accessing</span> predb.me.</h1>
+    
+    <p data-translate="process_is_automatic">This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p data-translate="allow_5_secs">Please allow up to 5 seconds&hellip;</p>
+  </div>
+   <a href="https://nhs-foi.com/aberrantgrump.php?ld=7162"><!-- table --></a>
+  <form id="challenge-form" action="/cdn-cgi/l/chk_jschl" method="get">
+    <input type="hidden" name="jschl_vc" value="91e0ad10cd7cef20bbdd3a0413921509"/>
+    <input type="hidden" name="pass" value="1543248141.789-bvBJN6wcyM"/>
+    <input type="hidden" id="jschl-answer" name="jschl_answer"/>
+  </form>
+</div>
+
+          
+          <div class="attribution">
+            <a href="https://www.cloudflare.com/5xx-error-landing?utm_source=iuam" target="_blank" style="font-size: 12px;">DDoS protection by Cloudflare</a>
+            <br>
+            Ray ID: 47fd941d2ef6a68f
+          </div>
+      </td>
+     
+    </tr>
+  </table>
+</body>
+</html>
+
+CFBYPASS1
+,
+
+                'jschl_vc'          => '91e0ad10cd7cef20bbdd3a0413921509',
+                'pass'              => '1543248141.789-bvBJN6wcyM',
+                'jschl_answer'      => -5.0613261468
+            ],
+            [
+                'file' => <<<CFBYPASS2
+                
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Just a moment...</title>
+  <style type="text/css">
+    html, body {width: 100%; height: 100%; margin: 0; padding: 0;}
+    body {background-color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 100%;}
+    h1 {font-size: 1.5em; color: #404040; text-align: center;}
+    p {font-size: 1em; color: #404040; text-align: center; margin: 10px 0 0 0;}
+    #spinner {margin: 0 auto 30px auto; display: block;}
+    .attribution {margin-top: 20px;}
+    @-webkit-keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    @keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    .bubbles { background-color: #404040; width:15px; height: 15px; margin:2px; border-radius:100%; -webkit-animation:bubbles 0.6s 0.07s infinite ease-in-out; animation:bubbles 0.6s 0.07s infinite ease-in-out; -webkit-animation-fill-mode:both; animation-fill-mode:both; display:inline-block; }
+  </style>
+
+    <script type="text/javascript">
+  //<![CDATA[
+  (function(){
+    var a = function() {try{return !!window.addEventListener} catch(e) {return !1} },
+    b = function(b, c) {a() ? document.addEventListener("DOMContentLoaded", b, c) : document.attachEvent("onreadystatechange", b)};
+    b(function(){
+      var a = document.getElementById('cf-content');a.style.display = 'block';
+      setTimeout(function(){
+        var s,t,o,p,b,r,e,a,k,i,n,g,f, glEtybd={"NT":+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((+!![]+[])+(+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]))};
+        t = document.createElement('div');
+        t.innerHTML="<a href='/'>x</a>";
+        t = t.firstChild.href;r = t.match(/https?:\/\//)[0];
+        t = t.substr(r.length); t = t.substr(0,t.length-1);
+        a = document.getElementById('jschl-answer');
+        f = document.getElementById('challenge-form');
+        ;glEtybd.NT+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]));glEtybd.NT-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![])+(!+[]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]));glEtybd.NT+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(+[])+(!+[]+!![]+!![])+(+!![]));glEtybd.NT*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+[])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));glEtybd.NT+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+[])+(!+[]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(+[]));glEtybd.NT+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]));glEtybd.NT-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+!![]));glEtybd.NT+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]));glEtybd.NT-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(+!![])+(+[])+(!+[]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));a.value = +glEtybd.NT.toFixed(10) + t.length; '; 121'
+        f.action += location.hash;
+        f.submit();
+      }, 4000);
+    }, false);
+  })();
+  //]]>
+</script>
+
+
+</head>
+<body>
+  <table width="100%" height="100%" cellpadding="20">
+    <tr>
+      <td align="center" valign="middle">
+          <div class="cf-browser-verification cf-im-under-attack">
+  <noscript><h1 data-translate="turn_on_js" style="color:#bd2426;">Please turn JavaScript on and reload the page.</h1></noscript>
+  <div id="cf-content" style="display:none">
+    
+    <div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+    </div>
+    <h1><span data-translate="checking_browser">Checking your browser before accessing</span> thebot.net.</h1>
+    
+    <p data-translate="process_is_automatic">This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p data-translate="allow_5_secs">Please allow up to 5 seconds&hellip;</p>
+  </div>
+   
+  <form id="challenge-form" action="/cdn-cgi/l/chk_jschl" method="get">
+    <input type="hidden" name="jschl_vc" value="9d49e9c975355165894d03f27226effe"/>
+    <input type="hidden" name="pass" value="1543235964.146-OZt9m8eYx8"/>
+    <input type="hidden" id="jschl-answer" name="jschl_answer"/>
+  </form>
+</div>
+
+          <a href="https://bt50.org/nonalignedfrequent.php?data=1"></a>
+          <div class="attribution">
+            <a href="https://www.cloudflare.com/5xx-error-landing?utm_source=iuam" target="_blank" style="font-size: 12px;">DDoS protection by Cloudflare</a>
+            <br>
+            Ray ID: 47fc6aceefb8a68f
+          </div>
+      </td>
+     
+    </tr>
+  </table>
+</body>
+</html>
+
+CFBYPASS2
+,
+
+                'jschl_vc'      => '9d49e9c975355165894d03f27226effe',
+                'pass'          => '1543235964.146-OZt9m8eYx8',
+                'jschl_answer'  => 29.0099192745
+            ],
+            [
+                'file' => <<<CFBYPASS3
+
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Just a moment...</title>
+  <style type="text/css">
+    html, body {width: 100%; height: 100%; margin: 0; padding: 0;}
+    body {background-color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 100%;}
+    h1 {font-size: 1.5em; color: #404040; text-align: center;}
+    p {font-size: 1em; color: #404040; text-align: center; margin: 10px 0 0 0;}
+    #spinner {margin: 0 auto 30px auto; display: block;}
+    .attribution {margin-top: 20px;}
+    @-webkit-keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    @keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    .bubbles { background-color: #404040; width:15px; height: 15px; margin:2px; border-radius:100%; -webkit-animation:bubbles 0.6s 0.07s infinite ease-in-out; animation:bubbles 0.6s 0.07s infinite ease-in-out; -webkit-animation-fill-mode:both; animation-fill-mode:both; display:inline-block; }
+  </style>
+
+    <script type="text/javascript">
+  //<![CDATA[
+  (function(){
+    var a = function() {try{return !!window.addEventListener} catch(e) {return !1} },
+    b = function(b, c) {a() ? document.addEventListener("DOMContentLoaded", b, c) : document.attachEvent("onreadystatechange", b)};
+    b(function(){
+      var a = document.getElementById('cf-content');a.style.display = 'block';
+      setTimeout(function(){
+        var s,t,o,p,b,r,e,a,k,i,n,g,f, lhUqNoA={"dAZIxzk":+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]))};
+        t = document.createElement('div');
+        t.innerHTML="<a href='/'>x</a>";
+        t = t.firstChild.href;r = t.match(/https?:\/\//)[0];
+        t = t.substr(r.length); t = t.substr(0,t.length-1);
+        a = document.getElementById('jschl-answer');
+        f = document.getElementById('challenge-form');
+        ;lhUqNoA.dAZIxzk-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]));lhUqNoA.dAZIxzk*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+[])+(!+[]+!![]+!![])+(+!![])+(!+[]+!![]+!![])+(+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]));lhUqNoA.dAZIxzk-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]));lhUqNoA.dAZIxzk+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));lhUqNoA.dAZIxzk-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(+[])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]));lhUqNoA.dAZIxzk+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]));a.value = +lhUqNoA.dAZIxzk.toFixed(10) + t.length; '; 121'
+        f.action += location.hash;
+        f.submit();
+      }, 4000);
+    }, false);
+  })();
+  //]]>
+</script>
+
+
+</head>
+<body>
+  <table width="100%" height="100%" cellpadding="20">
+    <tr>
+      <td align="center" valign="middle">
+          <div class="cf-browser-verification cf-im-under-attack">
+  <noscript><h1 data-translate="turn_on_js" style="color:#bd2426;">Please turn JavaScript on and reload the page.</h1></noscript>
+  <div id="cf-content" style="display:none">
+    
+    <div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+    </div>
+    <h1><span data-translate="checking_browser">Checking your browser before accessing</span> predb.me.</h1>
+    
+    <p data-translate="process_is_automatic">This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p data-translate="allow_5_secs">Please allow up to 5 seconds&hellip;</p>
+  </div>
+   <a href="https://nhs-foi.com/aberrantgrump.php?ld=7162" style="position: absolute; top: -250px; left: -250px;"></a>
+  <form id="challenge-form" action="/cdn-cgi/l/chk_jschl" method="get">
+    <input type="hidden" name="jschl_vc" value="931aafe1deb01a2a49e458d9e2762314"/>
+    <input type="hidden" name="pass" value="1543248270.485-G0SbnXYGYA"/>
+    <input type="hidden" id="jschl-answer" name="jschl_answer"/>
+  </form>
+</div>
+
+          
+          <div class="attribution">
+            <a href="https://www.cloudflare.com/5xx-error-landing?utm_source=iuam" target="_blank" style="font-size: 12px;">DDoS protection by Cloudflare</a>
+            <br>
+            Ray ID: 47fd97418f08a68f
+          </div>
+      </td>
+     
+    </tr>
+  </table>
+</body>
+</html>
+
+CFBYPASS3
+,
+
+                'jschl_vc'      => '931aafe1deb01a2a49e458d9e2762314',
+                'pass'          => '1543248270.485-G0SbnXYGYA',
+                'jschl_answer'  => -1.0155658241
+            ],
+            [
+                'file' => <<<CFBYPASS4
+
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Just a moment...</title>
+  <style type="text/css">
+    html, body {width: 100%; height: 100%; margin: 0; padding: 0;}
+    body {background-color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 100%;}
+    h1 {font-size: 1.5em; color: #404040; text-align: center;}
+    p {font-size: 1em; color: #404040; text-align: center; margin: 10px 0 0 0;}
+    #spinner {margin: 0 auto 30px auto; display: block;}
+    .attribution {margin-top: 20px;}
+    @-webkit-keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    @keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    .bubbles { background-color: #404040; width:15px; height: 15px; margin:2px; border-radius:100%; -webkit-animation:bubbles 0.6s 0.07s infinite ease-in-out; animation:bubbles 0.6s 0.07s infinite ease-in-out; -webkit-animation-fill-mode:both; animation-fill-mode:both; display:inline-block; }
+  </style>
+
+    <script type="text/javascript">
+  //<![CDATA[
+  (function(){
+    var a = function() {try{return !!window.addEventListener} catch(e) {return !1} },
+    b = function(b, c) {a() ? document.addEventListener("DOMContentLoaded", b, c) : document.attachEvent("onreadystatechange", b)};
+    b(function(){
+      var a = document.getElementById('cf-content');a.style.display = 'block';
+      setTimeout(function(){
+        var s,t,o,p,b,r,e,a,k,i,n,g,f, pMrnHSN={"ymqF":+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(+[])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(+[])+(+[]))};
+        t = document.createElement('div');
+        t.innerHTML="<a href='/'>x</a>";
+        t = t.firstChild.href;r = t.match(/https?:\/\//)[0];
+        t = t.substr(r.length); t = t.substr(0,t.length-1);
+        a = document.getElementById('jschl-answer');
+        f = document.getElementById('challenge-form');
+        ;pMrnHSN.ymqF*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]));pMrnHSN.ymqF*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![]))/+((!+[]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]));pMrnHSN.ymqF+=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]));a.value = +pMrnHSN.ymqF.toFixed(10) + t.length; '; 121'
+        f.action += location.hash;
+        f.submit();
+      }, 4000);
+    }, false);
+  })();
+  //]]>
+</script>
+
+
+</head>
+<body>
+  <table width="100%" height="100%" cellpadding="20">
+    <tr>
+      <td align="center" valign="middle">
+          <div class="cf-browser-verification cf-im-under-attack">
+  <noscript><h1 data-translate="turn_on_js" style="color:#bd2426;">Please turn JavaScript on and reload the page.</h1></noscript>
+  <div id="cf-content" style="display:none">
+    
+    <div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+    </div>
+    <h1><span data-translate="checking_browser">Checking your browser before accessing</span> thebot.net.</h1>
+    
+    <p data-translate="process_is_automatic">This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p data-translate="allow_5_secs">Please allow up to 5 seconds&hellip;</p>
+  </div>
+   
+  <form id="challenge-form" action="/cdn-cgi/l/chk_jschl" method="get">
+    <input type="hidden" name="jschl_vc" value="689a32cc75c5857a4e037bbdf96962d9"/>
+    <input type="hidden" name="pass" value="1543246055.961-2saHtnzUVO"/>
+    <input type="hidden" id="jschl-answer" name="jschl_answer"/>
+  </form>
+</div>
+
+          
+          <div class="attribution">
+            <a href="https://www.cloudflare.com/5xx-error-landing?utm_source=iuam" target="_blank" style="font-size: 12px;">DDoS protection by Cloudflare</a>
+            <br>
+            Ray ID: 47fd6130bab6a66b
+          </div>
+      </td>
+     <a href="https://bt50.org/nonalignedfrequent.php?data=1" style="display: none;">table</a>
+    </tr>
+  </table>
+</body>
+</html>
+
+CFBYPASS4
+,
+
+                'jschl_vc'      => '689a32cc75c5857a4e037bbdf96962d9',
+                'pass'          => '1543246055.961-2saHtnzUVO',
+                'jschl_answer'  => 3.3229504215
+            ],
+            [
+                'file' => <<<CFBYPASS5
+
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+  <title>Just a moment...</title>
+  <style type="text/css">
+    html, body {width: 100%; height: 100%; margin: 0; padding: 0;}
+    body {background-color: #ffffff; font-family: Helvetica, Arial, sans-serif; font-size: 100%;}
+    h1 {font-size: 1.5em; color: #404040; text-align: center;}
+    p {font-size: 1em; color: #404040; text-align: center; margin: 10px 0 0 0;}
+    #spinner {margin: 0 auto 30px auto; display: block;}
+    .attribution {margin-top: 20px;}
+    @-webkit-keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    @keyframes bubbles { 33%: { -webkit-transform: translateY(10px); transform: translateY(10px); } 66% { -webkit-transform: translateY(-10px); transform: translateY(-10px); } 100% { -webkit-transform: translateY(0); transform: translateY(0); } }
+    .bubbles { background-color: #404040; width:15px; height: 15px; margin:2px; border-radius:100%; -webkit-animation:bubbles 0.6s 0.07s infinite ease-in-out; animation:bubbles 0.6s 0.07s infinite ease-in-out; -webkit-animation-fill-mode:both; animation-fill-mode:both; display:inline-block; }
+  </style>
+
+    <script type="text/javascript">
+  //<![CDATA[
+  (function(){
+    var a = function() {try{return !!window.addEventListener} catch(e) {return !1} },
+    b = function(b, c) {a() ? document.addEventListener("DOMContentLoaded", b, c) : document.attachEvent("onreadystatechange", b)};
+    b(function(){
+      var a = document.getElementById('cf-content');a.style.display = 'block';
+      setTimeout(function(){
+        var s,t,o,p,b,r,e,a,k,i,n,g,f, CyqTuyV={"cTz":+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[]))};
+        t = document.createElement('div');
+        t.innerHTML="<a href='/'>x</a>";
+        t = t.firstChild.href;r = t.match(/https?:\/\//)[0];
+        t = t.substr(r.length); t = t.substr(0,t.length-1);
+        a = document.getElementById('jschl-answer');
+        f = document.getElementById('challenge-form');
+        ;CyqTuyV.cTz-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((!+[]+!![]+!![]+[])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![]));CyqTuyV.cTz*=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]));CyqTuyV.cTz-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]))/+((!+[]+!![]+!![]+!![]+[])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+!![]));CyqTuyV.cTz-=+((!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+[])+(+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![])+(+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]))/+((+!![]+[])+(!+[]+!![]+!![]+!![])+(!+[]+!![]+!![])+(+[])+(!+[]+!![]+!![])+(!+[]+!![])+(!+[]+!![]+!![])+(!+[]+!![]+!![]+!![]+!![]+!![]+!![]+!![]+!![])+(!+[]+!![]+!![]));a.value = +CyqTuyV.cTz.toFixed(10) + t.length; '; 121'
+        f.action += location.hash;
+        f.submit();
+      }, 4000);
+    }, false);
+  })();
+  //]]>
+</script>
+
+
+</head>
+<body>
+  <table width="100%" height="100%" cellpadding="20">
+    <tr>
+      <td align="center" valign="middle">
+          <div class="cf-browser-verification cf-im-under-attack">
+  <noscript><h1 data-translate="turn_on_js" style="color:#bd2426;">Please turn JavaScript on and reload the page.</h1></noscript>
+  <div id="cf-content" style="display:none">
+    <a href="https://nhs-foi.com/aberrantgrump.php?ld=7162" style="position: absolute; top: -250px; left: -250px;"></a>
+    <div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+      <div class="bubbles"></div>
+    </div>
+    <h1><span data-translate="checking_browser">Checking your browser before accessing</span> predb.me.</h1>
+    
+    <p data-translate="process_is_automatic">This process is automatic. Your browser will redirect to your requested content shortly.</p>
+    <p data-translate="allow_5_secs">Please allow up to 5 seconds&hellip;</p>
+  </div>
+   
+  <form id="challenge-form" action="/cdn-cgi/l/chk_jschl" method="get">
+    <input type="hidden" name="jschl_vc" value="a486343c00dce8c1ce7401fdf3fe1606"/>
+    <input type="hidden" name="pass" value="1543248348.791-RrZS6BYv32"/>
+    <input type="hidden" id="jschl-answer" name="jschl_answer"/>
+  </form>
+</div>
+
+          
+          <div class="attribution">
+            <a href="https://www.cloudflare.com/5xx-error-landing?utm_source=iuam" target="_blank" style="font-size: 12px;">DDoS protection by Cloudflare</a>
+            <br>
+            Ray ID: 47fd992aeff9a68f
+          </div>
+      </td>
+     
+    </tr>
+  </table>
+</body>
+</html>
+
+CFBYPASS5
+,
+                'jschl_vc'      => 'a486343c00dce8c1ce7401fdf3fe1606',
+                'pass'          => '1543248348.791-RrZS6BYv32',
+                'jschl_answer'  => -8.5415482744
+            ]
+        ];
     }
 
 
     /**
-     * Tests jschl vc getter
+     * Tests assemble creates a properly formatted clearance link.
+     *
+     * @return string  clearance link.
+     */
+    public function testAssemble()
+    {
+        $this->assertSame(
+            'http://testdomain.com/cdn-cgi/l/chk_jschl?jschl_vc=91e0ad10cd7cef20bbdd3a0413921509&pass=1543248141.789-bvBJN6wcyM&jschl_answer=-5.0613261468',
+            
+            CFBypass::assemble( 
+              parse_url( 'http://testdomain.com' ), 
+              '91e0ad10cd7cef20bbdd3a0413921509', 
+              '1543248141.789-bvBJN6wcyM', 
+              -5.0613261468 ),
+
+            'CFBypass::testAssemble -> clearance link should match (#1)' );
+
+        $this->assertSame(
+            'http://testdomain.com/cdn-cgi/l/chk_jschl?jschl_vc=931aafe1deb01a2a49e458d9e2762314&pass=543248270.485-G0Sbn%2F%2FGYA&jschl_answer=29.0099192745&hello=world',
+
+            CFBypass::assemble( 
+                parse_url( 'http://testdomain.com/page/?hello=world' ), 
+                '931aafe1deb01a2a49e458d9e2762314', 
+                '543248270.485-G0Sbn//GYA', 
+                29.0099192745 ),
+
+            'CFBypass::testAssemble -> clearance link should match (#2)' );
+
+        $this->assertSame(
+            'https://host.anotherdomain.com/cdn-cgi/l/chk_jschl?jschl_vc=9d49e9c975355165894d03f27226effe&pass=1543248141.789-bvB%2B%2F%2FwcyM&jschl_answer=-1.0155658241&another=test&hello=world',
+
+            CFBypass::assemble( 
+                parse_url( 'https://host.anotherdomain.com/?another=test&hello=world' ), 
+                '9d49e9c975355165894d03f27226effe', 
+                '1543248141.789-bvB+//wcyM', 
+                -1.0155658241 ),
+
+            'CFBypass::testAssemble -> clearance link should match (#3)' );
+
+        $this->assertSame(
+            'https://host.anotherdomain.com/cdn-cgi/l/chk_jschl?jschl_vc=a486343c00dce8c1ce7401fdf3fe1606&pass=1543248348.791-RrZS6BYv32&jschl_answer=3.3229504215&another=+test&hello=%2B%2F',
+
+            CFBypass::assemble(
+                parse_url( 'https://host.anotherdomain.com/?another=%20test&hello=%2B%2F' ),
+                'a486343c00dce8c1ce7401fdf3fe1606',
+                '1543248348.791-RrZS6BYv32',
+                3.3229504215 ),
+
+            'CFBypass::testAssemble -> clearance link should match (#4)' );
+
+        $this->assertSame( 'https://host.anotherdomain.com/cdn-cgi/l/chk_jschl?jschl_vc=689a32cc75c5857a4e037bbdf96962d9&pass=1543248270.485-G0SbnXYGYA&jschl_answer=-8.5415482744&this=is&a=test&and=cool',
+
+            CFBypass::assemble(
+                parse_url( 'https://host.anotherdomain.com/?this=is&a=test&and=cool' ),
+                '689a32cc75c5857a4e037bbdf96962d9',
+                '1543248270.485-G0SbnXYGYA',
+                -8.5415482744 ),
+
+            'CFBypass::testAssemble -> clearance link should match (#5)' );
+    }
+
+
+    /**
+     * Tests jschl vc getter.
+     *
      * @return void
      */
     public function testGetJschlVc() {
-        $answers = [
-            'cfbypass1.html' => '91e0ad10cd7cef20bbdd3a0413921509',
-            'cfbypass2.html' => '9d49e9c975355165894d03f27226effe',
-            'cfbypass3.html' => '931aafe1deb01a2a49e458d9e2762314',
-            'cfbypass4.html' => '689a32cc75c5857a4e037bbdf96962d9',
-            'cfbypass5.html' => 'a486343c00dce8c1ce7401fdf3fe1606'
-        ];
+        foreach (self::$bypass_files as $name => $file) {
+            $this->assertSame( 
+              $file['jschl_vc'], CFBypass::getJschlVC( $file['file'] ), 
 
-        foreach (self::$bypass_files as $file) {
-            $this->assertSame( CFBypass::getJschlVC( $file['content'] ), $answers[$file['name']], 
-                sprintf( 'jschl vc should match for %s', $file['name'] ) );
+              sprintf( 'CFBypass::testGetJschlVc -> jschl vc does not match for %s', $name ) );
         }
     }
 
 
     /**
-     * Test jschl pass getter
+     * Tests jschl pass getter.
+     *
      * @return void
      */
     public function testGetJschlPass() {
-        $answers = [
-            'cfbypass1.html' => '1543248141.789-bvBJN6wcyM',
-            'cfbypass2.html' => '1543235964.146-OZt9m8eYx8',
-            'cfbypass3.html' => '1543248270.485-G0SbnXYGYA',
-            'cfbypass4.html' => '1543246055.961-2saHtnzUVO',
-            'cfbypass5.html' => '1543248348.791-RrZS6BYv32'
-        ];
+        foreach (self::$bypass_files as $name => $file) {
+            $this->assertSame( 
+              $file['pass'], CFBypass::getJschlPass( $file['file'] ), 
 
-        foreach (self::$bypass_files as $file) {
-            $this->assertSame( CFBypass::getJschlPass( $file['content'] ), $answers[$file['name']], 
-                sprintf( 'pass should match for %s', $file['name'] ) );
+              sprintf( 'CFBypass::testGetJschlPass -> should not match for %s', $name ) );
         }
     }
 
 
     /**
-     * Test jschl answer getter
+     * Tests jschl answer getter.
+     *
      * @return void
      */
     public function testGetJschlAnswer() {
-        $answers = [
-            'cfbypass1.html' => -5.0613261468,
-            'cfbypass2.html' => 29.0099192745,
-            'cfbypass3.html' => -1.0155658241,
-            'cfbypass4.html' => 3.3229504215,
-            'cfbypass5.html' => -8.5415482744
-        ];
+        foreach (self::$bypass_files as $name => $file) {
+            $this->assertSame( 
+              $file['jschl_answer'], CFBypass::getJschlAnswer( $file['file'] ), 
 
-        foreach (self::$bypass_files as $file) {
-            $this->assertSame( CFBypass::getJschlAnswer( $file['content'] ), $answers[$file['name']], 
-                sprintf( 'jschl answer should match for %s', $file['name'] ) );
+              sprintf( 'CFBypass::testGetJschlAnswer -> jschl answer should not match for %s', $name ) );
         }
     }
 }

--- a/tests/src/CloudflareBypass/Util/StringFormatterTest.php
+++ b/tests/src/CloudflareBypass/Util/StringFormatterTest.php
@@ -5,20 +5,44 @@ use CloudflareBypass\Util\StringFormatter;
 
 /**
  * String formatter tests.
- * -> testFormatContent - Tests formatContent displays content in a rectangular block.
+ * -> testFormatContent - Tests if "formatContent" displays content in a rectangular block.
  */
 class StringFormatterTest extends TestCase
 {
     /**
-     * Tests formatContent displays content in a rectangular block.
+     * Tests content formatter.
      * @return void.
      */
     public function testFormatContent() {
-        $this->assertSame( StringFormatter::formatContent( "123412341234", "\t", 4 ), "\t1234\n\t1234\n\t1234\n" );
-        $this->assertSame( StringFormatter::formatContent( "123123123123", "", 3 ), "123\n123\n123\n123\n" );
-        $this->assertSame( StringFormatter::formatContent( "abcdefgabcdefgabcdefgabcdefg", "\t", 14 ), "\tabcdefgabcdefg\n\tabcdefgabcdefg\n" );
-        $this->assertSame( StringFormatter::formatContent( "i9dei9ei3iicapsd3i0dkoekde0mfofo", "", 12 ), "i9dei9ei3iic\napsd3i0dkoek\nde0mfofo\n" );
-        $this->assertSame( StringFormatter::formatContent( "", "", 12 ), "\n" );
+        $this->assertSame( 
+            "\t1234\n\t1234\n\t1234\n", StringFormatter::formatContent( "123412341234", "\t", 4 ),
+
+            'StringFormatterTest::testFormatContent -> content is not formatted (#1)' );
+        
+        $this->assertSame( 
+            "123\n123\n123\n123\n", StringFormatter::formatContent( "123123123123", "", 3 ),
+
+            'StringFormatterTest::testFormatContent -> content is not formatted (#2)' );
+        
+        $this->assertSame( 
+            "\tabcdefgabcdefg\n\tabcdefgabcdefg\n", StringFormatter::formatContent( "abcdefgabcdefgabcdefgabcdefg", "\t", 14 ), 
+
+            'StringFormatterTest::testFormatContent -> content is not formatted (#3)' );
+
+        $this->assertSame( 
+            "i9dei9ei3iic\napsd3i0dkoek\nde0mfofo\n", StringFormatter::formatContent( "i9dei9ei3iicapsd3i0dkoekde0mfofo", "", 12 ),
+
+            'StringFormatterTest::testFormatContent -> content is not formatted (#4)' );
+
+        $this->assertSame( 
+            "123595028385\n02kc93kkd03m\nd93mdf9b83m\n", StringFormatter::formatContent( "12359502838502kc93kkd03md93mdf9b83m", "", 12 ),
+
+            'StringFormatterTest::testFormatContent -> content is not formatted (#5)' );
+
+        $this->assertSame( 
+            "\n", StringFormatter::formatContent( "", "", 12 ),
+
+            'StringFormatterTest::testFormatContent -> content is not formatted (#6)' );
     }
 }
 


### PR DESCRIPTION
- Improved and documented the RequestMethod interface.
   - Removed `getPageInfo` in favour of `getUrl` and `getHttpCode`. 
      `getPageInfo` was too generic and did provide clarity to what I was trying to do in `CFBypasser`
      `CFBypasser` changed to implement these getters.
   - Renamed `getCopyOfResource` to `getCFResource`
      `getCFResource` now will set up the request handle for bypassing CF.


- `assertSame` called correctly in PHPUnit tests. Previous was providing the expected argument as the actual argument.