### PR TITLE
fixing a bug related to missing cache_path

### DIFF
--- a/src/CloudflareBypass/CFCore.php
+++ b/src/CloudflareBypass/CFCore.php
@@ -44,6 +44,8 @@ class CFCore
      */
     public function __construct( $config = array() )
     {
+        $config['cache_path'] = isset($config['cache_path']) ? $config['cache_path'] : sys_get_temp_dir()."/cf-bypass";
+        
         if (!isset( $config['cache'] ) || $config['cache'])
             $this->cache = new Storage( $config['cache_path'] );
 


### PR DESCRIPTION
fixing a bug related to missing cache_path in the passed config to the CFCore constructor.
before this, when the client omits to set cache_path in the config array, the Storage cache handler tries to unlink the os's root files!
issue link: https://github.com/KyranRana/cloudflare-bypass/issues/92