### PR TITLE
Cloudflare bypass streamcontext fix

### DIFF
--- a/src/CloudflareBypass/Base/RequestMethod/RequestMethod.php
+++ b/src/CloudflareBypass/Base/RequestMethod/RequestMethod.php
@@ -9,6 +9,18 @@ namespace CloudflareBypass\Base\RequestMethod;
  */
 interface RequestMethod {
 
+    // {{{ Misc
+
+    /**
+     * Closes the current request.
+     *
+     * @access public
+     */
+    public function close();
+
+
+    // ------------------------------------------------------------------------------------------------
+
     // {{{ Getters
 
     /**

--- a/src/CloudflareBypass/RequestMethod/Curl.php
+++ b/src/CloudflareBypass/RequestMethod/Curl.php
@@ -111,7 +111,11 @@ class Curl implements \CloudflareBypass\Base\RequestMethod\RequestMethod
      */
     public function close()
     {
-        curl_close( $this->ch );
+        if ($this->ch != null) {
+            curl_close( $this->ch );
+        }
+        
+        $this->ch = null;
     }
 
     // }}}

--- a/src/CloudflareBypass/RequestMethod/Stream.php
+++ b/src/CloudflareBypass/RequestMethod/Stream.php
@@ -68,6 +68,17 @@ class Stream implements \CloudflareBypass\Base\RequestMethod\RequestMethod
         return stream_context_get_options( $this->ctx );
     }
 
+
+    /**
+     * Closes request.
+     *
+     * @access public
+     */
+    public function close()
+    {
+        // Not implemented...
+    }
+
     // }}}
 
     // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
+ Added close method to request method interface as CFBypasser requires it.
+ Implemented close method in the stream object (doesn't do anything).
+ Added a check to cURL's close method to ensure handle is closed if it is open.