### PR TITLE
Fix bypass by decoding url

### DIFF
--- a/src/main/Model/UAM/UAMPageFormParams.php
+++ b/src/main/Model/UAM/UAMPageFormParams.php
@@ -39,7 +39,7 @@ class UAMPageFormParams
             $jschlVcMatches[1],
             $passMatches[1],
             self::getJschlAnswerFromPage($pageAttributes),
-            $urlMatches[1]
+            htmlspecialchars_decode($urlMatches[1])
         );
     }
 


### PR DESCRIPTION
The bypass is currently not working, @momala454 found a fix in #164, I've only put that change into a proper pull request. According to my own tests, this works.