### PR TITLE
Drops 7.0/7.1 support - related #157

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.0",
+    "php": "^7.2",
     "myclabs/php-enum": "^1.6.6",
     "KyranRana/simple-javascript-compilation": "^0.3.1",
     "ext-curl": "*",


### PR DESCRIPTION
Improves maintainability by following actual maintained PHP versions and
dropping previous support