### PR TITLE
Adds Issue Template - related #157

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. If you fail to provide this
+information, we cannot debug your issue and will close it. We will, however,
+reopen it if you later provide the information.
+
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**Description**
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+**Steps to reproduce the issue:**
+1.
+1.
+1.
+
+**Describe the results you received:**
+
+
+**Describe the results you expected:**
+
+
+**Additional information you deem important (e.g. issue happens only occasionally):**
+
+**Provide some logs**
+
+<details>
+<pre>
+(paste logs)
+</pre>
+</details>
+
+**Version you are using (you may find this information in your `composer.lock` file)**
+
+```
+(paste your output here)
+```
+
+**PHP Version you are using**
+
+```
+(paste your output here)
+```


### PR DESCRIPTION
As this template asks for a product version, a stable release process
should be used (see #157) to identify which version of the codebase is
used.
This should close #138, close #140, close #141, close #143, close #146, close #150, close #151, close #152, close #153, close #154, close #155, close #156, close #158, close #159, close #160, close #161, close #164 and close #168